### PR TITLE
Update frontend tutorial to make more use of Wagtail's data

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,12 +475,13 @@ class BlogPage(Page):
     body = RichTextField(blank=True)
 
     api_fields = [
+        APIField('date'),
         APIField('intro'),
         APIField('body'),
     ]
 ```
 
-You will now be able to fetch the pages data through the REST API. For an example query, try visiting <http://127.0.0.1:8000/api/v2/pages/?type=blog.BlogPage&fields=intro,body> on your web browser.
+You will now be able to fetch the pages data through the REST API. For an example query, try visiting <http://127.0.0.1:8000/api/v2/pages/?type=blog.BlogPage&fields=date,intro,body> on your web browser.
 
 ### Fetching data from the Wagtail API in the Next.js frontend
 
@@ -494,19 +495,19 @@ export default async function BlogIndex() {
     {
       id: 1,
       title: "First post",
+      date: "2022-01-01",
       intro: "This is the first post",
       meta: {
         slug: "first-post",
-        first_published_at: "2022-01-011T09:00:00Z",
       },
     },
     {
       id: 2,
       title: "Second post",
+      date: "2021-01-02",
       intro: "This is the second post",
       meta: {
         slug: "first-post",
-        first_published_at: "2021-01-011T09:00:00Z",
       },
     },
   ];
@@ -523,8 +524,8 @@ export default async function BlogIndex() {
             <a className="underline" href={`blog/${child.meta.slug}`}>
               <h2>{child.title}</h2>
             </a>
-            <time dateTime={child.meta.first_published_at}>
-              {new Date(child.meta.first_published_at).toDateString()}
+            <time dateTime={child.date}>
+              {new Date(child.date).toDateString()}
             </time>
             <p>{child.intro}</p>
           </li>
@@ -545,11 +546,10 @@ To do so, we can change the `posts` definition with the following:
 interface BlogPage {
   id: number;
   meta: {
-    type: string;
     slug: string;
-    first_published_at: string;
   };
   title: string;
+  date: string;
   intro: string;
 }
 
@@ -557,7 +557,7 @@ export default async function BlogIndex() {
   const data = await fetch(
     `http://127.0.0.1:8000/api/v2/pages/?${new URLSearchParams({
       type: "blog.BlogPage",
-      fields: "intro",
+      fields: ["date", "intro"].join(","),
     })}`,
     {
       headers: {
@@ -581,11 +581,10 @@ We'll just add one more page to complete our Next.js website, which is the blog 
 interface BlogPage {
   id: number;
   meta: {
-    type: string;
     slug: string;
-    first_published_at: string;
   };
   title: string;
+  date: string;
   intro: string;
   body: string;
 }
@@ -599,7 +598,7 @@ export default async function Blog({
     `http://127.0.0.1:8000/api/v2/pages/?${new URLSearchParams({
       slug,
       type: "blog.BlogPage",
-      fields: ["intro", "body"].join(","),
+      fields: ["date", "intro", "body"].join(","),
     })}`,
     {
       headers: {
@@ -614,8 +613,8 @@ export default async function Blog({
     <main>
       <div>
         <h1 className="text-4xl font-bold mb-2">{post.title}</h1>
-        <time dateTime={post.meta.first_published_at}>
-          {new Date(post.meta.first_published_at).toDateString()}
+        <time dateTime={post.date}>
+          {new Date(post.date).toDateString()}
         </time>
         <p className="my-4">{post.intro}</p>
       </div>

--- a/README.md
+++ b/README.md
@@ -515,8 +515,8 @@ export default async function BlogIndex() {
   return (
     <main>
       <div className="mb-8">
-        <h1>Title</h1>
-        <p>Some introduction</p>
+        <h1 className="text-4xl font-bold mb-2">Blog</h1>
+        <div><p>Some introduction</p></div>
       </div>
       <ul>
         {posts.map((child) => (
@@ -543,6 +543,11 @@ Note that the data is still a placeholder and hardcoded in the Next.js code. We 
 To do so, we can change the `posts` definition with the following:
 
 ```tsx
+interface BlogIndexPage {
+  title: string;
+  intro: string;
+}
+
 interface BlogPage {
   id: number;
   meta: {
@@ -554,6 +559,20 @@ interface BlogPage {
 }
 
 export default async function BlogIndex() {
+  const indexPages = await fetch(
+    `http://localhost:8000/api/v2/pages/?${new URLSearchParams({
+      type: "blog.BlogIndexPage",
+      fields: "intro",
+    })}`,
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  ).then((response) => response.json());
+
+  const index: BlogIndexPage = indexPages.items[0];
+
   const data = await fetch(
     `http://127.0.0.1:8000/api/v2/pages/?${new URLSearchParams({
       type: "blog.BlogPage",
@@ -568,8 +587,17 @@ export default async function BlogIndex() {
 
   const posts: BlogPage[] = data.items;
 
-  // The rest stays the same
-  // ...
+  return (
+    <main>
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold mb-2">{index.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: index.intro }}></div>
+      </div>
+
+      // The rest stays the same
+      // ...
+    </main>
+  );
 }
 ```
 

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,3 +1,8 @@
+interface BlogIndexPage {
+  title: string;
+  intro: string;
+}
+
 interface BlogPage {
   id: number;
   meta: {
@@ -9,6 +14,20 @@ interface BlogPage {
 }
 
 export default async function BlogIndex() {
+  const indexPages = await fetch(
+    `http://localhost:8000/api/v2/pages/?${new URLSearchParams({
+      type: "blog.BlogIndexPage",
+      fields: "intro",
+    })}`,
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  ).then((response) => response.json());
+
+  const index: BlogIndexPage = indexPages.items[0];
+
   const data = await fetch(
     `http://127.0.0.1:8000/api/v2/pages/?${new URLSearchParams({
       type: "blog.BlogPage",
@@ -26,8 +45,8 @@ export default async function BlogIndex() {
   return (
     <main>
       <div className="mb-8">
-        <h1>Title</h1>
-        <p>Some introduction</p>
+        <h1 className="text-4xl font-bold mb-2">{index.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: index.intro }}></div>
       </div>
       <ul>
         {posts.map((child) => (

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,19 +1,18 @@
 interface BlogPage {
   id: number;
   meta: {
-    type: string;
     slug: string;
-    first_published_at: string;
   };
   title: string;
+  date: string;
   intro: string;
 }
 
 export default async function BlogIndex() {
   const data = await fetch(
-    `http://localhost:8000/api/v2/pages/?${new URLSearchParams({
+    `http://127.0.0.1:8000/api/v2/pages/?${new URLSearchParams({
       type: "blog.BlogPage",
-      fields: "intro",
+      fields: ["date", "intro"].join(","),
     })}`,
     {
       headers: {
@@ -36,8 +35,8 @@ export default async function BlogIndex() {
             <a className="underline" href={`blog/${child.meta.slug}`}>
               <h2>{child.title}</h2>
             </a>
-            <time dateTime={child.meta.first_published_at}>
-              {new Date(child.meta.first_published_at).toDateString()}
+            <time dateTime={child.date}>
+              {new Date(child.date).toDateString()}
             </time>
             <p>{child.intro}</p>
           </li>


### PR DESCRIPTION
This targets #4, making this a separate PR in case we're not comfortable updating this much of the instructions very close to the workshop. This contains two main changes:

- Use the `date` field we've added to the `BlogPage` model instead of the base Page model's meta `first_published_at`. At DjangoCon, the use of `first_published_at` raised some questions because it does not reflect the `date` field we added and input in the CMS.
- Update the frontend's blog index page to fetch the content from Wagtail. I think I intentionally did this for DjangoCon because it's easier to explain when we only have one API query in the file, but we can add this now if we want to, as it will make sure the blog index page gets fed with the content we update in the CMS.

I tried this and it all works well, but if you'd rather not risk it we can just merge #4 without this.

If we want this, then merge this PR first, which will roll into #4. Then, merge #4.